### PR TITLE
MacOS deployment improvements

### DIFF
--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -81,15 +81,16 @@ pushd "build"
 
         darwin*)
             export MACOSX_DEPLOYMENT_TARGET="$LL_BUILD_DARWIN_DEPLOY_TARGET"
-	    export MACOSX_ARCHITECTURES="arm64;x86_64"
+            export MACOSX_ARCHITECTURES="arm64;x86_64"
+            export MACOSX_EXTRA_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET='${MACOSX_DEPLOYMENT_TARGET}' -DCMAKE_OSX_ARCHITECTURES='${MACOSX_ARCHITECTURES}' -DCMAKE_IGNORE_PREFIX_PATH='/usr/local/'"
 
-	    # force CPM dependencies glfw and freetype to be built statically to make built executables easier to deploy anywhere
-	    patch --directory "$top/$source_dir" -p1 < "$top/tracy-deps-static.patch"
+            # force CPM dependencies glfw and freetype to be built statically to make built executables easier to deploy anywhere
+            patch --directory "$top/$source_dir" -p1 < "$top/tracy-deps-static.patch"
 
             mkdir -p "$stage_dir/bin"
             mkdir -p "capture"
             pushd "capture"
-                cmake "$top/$source_dir/capture" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES="${MACOSX_ARCHITECTURES}"
+                cmake "$top/$source_dir/capture" -G Ninja ${MACOSX_EXTRA_CMAKE_ARGS}
 
                 cmake --build . --config Release
 
@@ -98,7 +99,7 @@ pushd "build"
 
             mkdir -p "csvexport"
             pushd "csvexport"
-                cmake "$top/$source_dir/csvexport" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES="${MACOSX_ARCHITECTURES}"
+                cmake "$top/$source_dir/csvexport" -G Ninja ${MACOSX_EXTRA_CMAKE_ARGS}
                 cmake --build . --config Release
 
                 cp -a tracy-csvexport $stage_dir/bin
@@ -106,7 +107,7 @@ pushd "build"
 
             mkdir -p "profiler"
             pushd "profiler"
-                cmake "$top/$source_dir/profiler" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES="${MACOSX_ARCHITECTURES}"
+                cmake "$top/$source_dir/profiler" -G Ninja ${MACOSX_EXTRA_CMAKE_ARGS}
                 cmake --build . --config Release
 
                 cp -a tracy-profiler $stage_dir/bin
@@ -114,7 +115,7 @@ pushd "build"
 
             mkdir -p "update"
             pushd "update"
-                cmake "$top/$source_dir/update" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES="${MACOSX_ARCHITECTURES}"
+                cmake "$top/$source_dir/update" -G Ninja ${MACOSX_EXTRA_CMAKE_ARGS}
                 cmake --build . --config Release
 
                 cp -a tracy-update $stage_dir/bin

--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -81,11 +81,16 @@ pushd "build"
 
         darwin*)
             export MACOSX_DEPLOYMENT_TARGET="$LL_BUILD_DARWIN_DEPLOY_TARGET"
+	    export MACOSX_ARCHITECTURES="arm64;x86_64"
+
+	    # force CPM dependencies glfw and freetype to be built statically to make built executables easier to deploy anywhere
+	    patch --directory "$top/$source_dir" -p1 < "$top/tracy-deps-static.patch"
 
             mkdir -p "$stage_dir/bin"
             mkdir -p "capture"
             pushd "capture"
-                cmake "$top/$source_dir/capture" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
+                cmake "$top/$source_dir/capture" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES="${MACOSX_ARCHITECTURES}"
+
                 cmake --build . --config Release
 
                 cp -a tracy-capture $stage_dir/bin
@@ -93,7 +98,7 @@ pushd "build"
 
             mkdir -p "csvexport"
             pushd "csvexport"
-                cmake "$top/$source_dir/csvexport" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
+                cmake "$top/$source_dir/csvexport" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES="${MACOSX_ARCHITECTURES}"
                 cmake --build . --config Release
 
                 cp -a tracy-csvexport $stage_dir/bin
@@ -101,7 +106,7 @@ pushd "build"
 
             mkdir -p "profiler"
             pushd "profiler"
-                cmake "$top/$source_dir/profiler" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
+                cmake "$top/$source_dir/profiler" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES="${MACOSX_ARCHITECTURES}"
                 cmake --build . --config Release
 
                 cp -a tracy-profiler $stage_dir/bin
@@ -109,7 +114,7 @@ pushd "build"
 
             mkdir -p "update"
             pushd "update"
-                cmake "$top/$source_dir/update" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
+                cmake "$top/$source_dir/update" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES="${MACOSX_ARCHITECTURES}"
                 cmake --build . --config Release
 
                 cp -a tracy-update $stage_dir/bin

--- a/tracy-deps-static.patch
+++ b/tracy-deps-static.patch
@@ -1,0 +1,20 @@
+diff --git a/cmake/vendor.cmake b/cmake/vendor.cmake
+index bd53a4db..100040e6 100644
+--- a/cmake/vendor.cmake
++++ b/cmake/vendor.cmake
+@@ -49,6 +49,7 @@ if(NOT USE_WAYLAND AND NOT EMSCRIPTEN)
+                 "GLFW_BUILD_TESTS OFF"
+                 "GLFW_BUILD_DOCS OFF"
+                 "GLFW_INSTALL OFF"
++                "GLFW_LIBRARY_TYPE STATIC"
+         )
+         add_library(TracyGlfw3 INTERFACE)
+         target_link_libraries(TracyGlfw3 INTERFACE glfw)
+@@ -70,6 +71,7 @@ else()
+         OPTIONS
+             "FT_DISABLE_HARFBUZZ ON"
+             "FT_WITH_HARFBUZZ OFF"
++            "BUILD_SHARED_LIBS OFF"
+     )
+     add_library(TracyFreetype INTERFACE)
+     target_link_libraries(TracyFreetype INTERFACE freetype)


### PR DESCRIPTION
Patch tracy to use statically linked upstream libs for freetype and glfw, and turned on universal builds